### PR TITLE
fix: mock API key verification in router tests

### DIFF
--- a/tests/unit/api/test_router.py
+++ b/tests/unit/api/test_router.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+from fastapi import Header
 import httpx
 
 from oce.api.router import get_application
 from oce.application.service import BatchUploadResult, RetrievalResult
-from oce.auth import verify_api_key
+from oce.auth import _unauthorized, verify_api_key
 from oce.domain.services.search import SearchHit
 from oce.main import app
 
@@ -70,11 +71,13 @@ class StubApplication:
         )
 
 
-async def mock_verify_api_key(authorization: str | None = None) -> str:
-    """测试用模拟认证，接受任何格式正确的 Bearer token。"""
-    if authorization and authorization.startswith("Bearer "):
-        return authorization.removeprefix("Bearer ")
-    return "test-token"
+async def mock_verify_api_key(authorization: str | None = Header(default=None)) -> str:
+    """测试用模拟认证：接受任何 Bearer token，无 token 或格式错误则拒绝。"""
+    if authorization is None:
+        raise _unauthorized("You didn't provide an API key.")
+    if not authorization.startswith("Bearer "):
+        raise _unauthorized("Invalid API key format. Expected 'Bearer <key>'")
+    return authorization.removeprefix("Bearer ")
 
 
 def _transport() -> httpx.ASGITransport:

--- a/tests/unit/api/test_router.py
+++ b/tests/unit/api/test_router.py
@@ -8,6 +8,7 @@ import httpx
 
 from oce.api.router import get_application
 from oce.application.service import BatchUploadResult, RetrievalResult
+from oce.auth import verify_api_key
 from oce.domain.services.search import SearchHit
 from oce.main import app
 
@@ -69,8 +70,16 @@ class StubApplication:
         )
 
 
+async def mock_verify_api_key(authorization: str | None = None) -> str:
+    """测试用模拟认证，接受任何格式正确的 Bearer token。"""
+    if authorization and authorization.startswith("Bearer "):
+        return authorization.removeprefix("Bearer ")
+    return "test-token"
+
+
 def _transport() -> httpx.ASGITransport:
     app.dependency_overrides[get_application] = lambda: StubApplication()
+    app.dependency_overrides[verify_api_key] = mock_verify_api_key
     return httpx.ASGITransport(app=app)
 
 
@@ -147,6 +156,7 @@ async def test_paths_endpoint_deduplicates_chunks_by_path():
             return RetrievalResult((first, second), "formatted", 12)
 
     app.dependency_overrides[get_application] = lambda: DuplicateApplication()
+    app.dependency_overrides[verify_api_key] = mock_verify_api_key
     async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
         response = await client.post(
             "/agents/codebase-retrieval-paths",


### PR DESCRIPTION
Tests were failing with 401 Unauthorized because they were using the test token 'sk-dev' but the real verify_api_key() function was validating against the production API key from settings.

Solution:
- Add mock_verify_api_key() function that accepts any Bearer token
- Override the verify_api_key dependency in test fixtures
- This allows tests to focus on contract validation without auth concerns

Fixes:
- test_reload_embedding_credentials_contract
- test_batch_upload_contract
- test_codebase_retrieval_and_paths_contracts
- test_paths_endpoint_deduplicates_chunks_by_path
- test_nullable_blob_payload_is_normalized
- test_project_overview_contract