### PR TITLE
fix: 修复个人模式 SQLite 锁冲突问题

### DIFF
--- a/src/oce/shared/database/sqlite_adapter.py
+++ b/src/oce/shared/database/sqlite_adapter.py
@@ -4,13 +4,35 @@ from __future__ import annotations
 
 from typing import Any
 
+from sqlalchemy import event
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+from sqlalchemy.pool import StaticPool
 
 
 class SQLiteAdapter:
     def create_engine(self, url: str, **kwargs: Any) -> AsyncEngine:
-        return create_async_engine(
+        """创建 SQLite 异步引擎，针对个人模式优化以避免锁冲突。
+
+        - WAL 模式：允许读写并发
+        - busy_timeout：等待锁最多 30 秒
+        - StaticPool：单连接池，避免多连接死锁
+        """
+        engine = create_async_engine(
             url,
-            connect_args={"check_same_thread": False},
+            connect_args={
+                "check_same_thread": False,
+                "timeout": 30.0,  # busy_timeout 30 秒
+            },
+            poolclass=StaticPool,  # 个人模式单连接，避免死锁
             echo=kwargs.get("echo", False),
         )
+
+        # 启用 WAL 模式以支持并发读写
+        @event.listens_for(engine.sync_engine, "connect")
+        def _set_sqlite_pragma(dbapi_conn, _connection_record):
+            cursor = dbapi_conn.cursor()
+            cursor.execute("PRAGMA journal_mode=WAL")
+            cursor.execute("PRAGMA synchronous=NORMAL")  # WAL 模式下可以降低同步级别
+            cursor.close()
+
+        return engine

--- a/tests/integration/test_sqlite_concurrent_writes.py
+++ b/tests/integration/test_sqlite_concurrent_writes.py
@@ -1,0 +1,92 @@
+"""集成测试：验证 SQLite WAL 模式下监控指标并发写入不会死锁。
+
+模拟个人模式场景：后台 metrics sink flush + 多个并发 session 写入。
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from oce.infrastructure.metrics.sql_metrics_sink import SqlMetricsSink
+from oce.infrastructure.persistence.models import (
+    ApiCallMetricModel,
+    ResourceSampleModel,
+)
+from oce.shared.database.session import Base
+from oce.shared.database.sqlite_adapter import SQLiteAdapter
+from oce.shared.metrics import ApiCallRecord, ResourceSampleRecord
+
+
+async def test_concurrent_writes_no_lock_conflict():
+    """并发写入 API 调用记录和资源采样，验证不会出现 database locked 错误。"""
+    with TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        url = f"sqlite+aiosqlite:///{db_path.as_posix()}"
+
+        # 使用修复后的 SQLite 适配器
+        engine = SQLiteAdapter().create_engine(url, echo=False)
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+        # 创建 metrics sink（短 flush 间隔模拟高频写入）
+        sink = SqlMetricsSink(factory, flush_interval_seconds=0.1, max_buffer=100)
+        await sink.start()
+
+        try:
+            # 并发写入 API 调用记录和资源采样
+            for i in range(50):
+                # API 调用记录
+                sink.record_api_call(ApiCallRecord(
+                    ts=datetime.now(timezone.utc),
+                    endpoint=f"/test/{i}",
+                    method="GET",
+                    status_code=200,
+                    latency_ms=10 + i,
+                    error_type=None,
+                ))
+                # 资源采样
+                if i % 5 == 0:
+                    sink.record_resource_sample(ResourceSampleRecord(
+                        disk_data_bytes=1024 * i,
+                        disk_free_bytes=1024 * 1024 * 100,
+                        disk_total_bytes=1024 * 1024 * 500,
+                        mem_rss_bytes=1024 * 1024 * 50,
+                        mem_percent=10.0,
+                        cpu_percent=5.0,
+                    ))
+                # 每 10 条休眠一下，让 flush 有机会并发执行
+                if i % 10 == 0:
+                    await asyncio.sleep(0.05)
+
+            # 等待所有写入完成
+            await asyncio.sleep(1.0)
+
+        finally:
+            await sink.stop()
+            await engine.dispose()
+
+        # 验证数据写入成功（重新连接以确保 WAL 已关闭）
+        verify_engine = SQLiteAdapter().create_engine(url, echo=False)
+        verify_factory = async_sessionmaker(verify_engine, class_=AsyncSession, expire_on_commit=False)
+
+        async with verify_factory() as session:
+            api_count = await session.scalar(
+                select(func.count()).select_from(ApiCallMetricModel)
+            )
+            resource_count = await session.scalar(
+                select(func.count()).select_from(ResourceSampleModel)
+            )
+
+        await verify_engine.dispose()
+
+        # 应该至少写入了大部分数据（允许 deque maxlen 丢弃少量）
+        assert api_count >= 45, f"Expected >=45 API records, got {api_count}"
+        assert resource_count >= 8, f"Expected >=8 resource samples, got {resource_count}"
+        print(f"✓ Wrote {api_count} API calls and {resource_count} resource samples without lock errors")


### PR DESCRIPTION
## 问题描述

修复 #3 - 个人模式下 SQLite 出现 database is locked 错误，导致监控指标写入失败。

## 根本原因

1. **默认日志模式不支持并发**：SQLite 默认模式不允许读写并发
2. **超时时间太短**：默认 busy_timeout 不足，等待锁时间过短
3. **多连接竞争**：多个连接可能导致死锁

## 解决方案

### 修改文件
- src/oce/shared/database/sqlite_adapter.py - 优化 SQLite 引擎配置

### 关键改进
1. **启用 WAL 模式**：PRAGMA journal_mode=WAL - 支持一写多读并发
2. **优化同步级别**：PRAGMA synchronous=NORMAL - WAL 模式下安全且更快
3. **延长超时**：	imeout=30.0 - 等待锁最多 30 秒
4. **单连接池**：StaticPool - 避免多连接死锁

### 测试
- ✅ 所有现有单元测试通过（11 个）
- ✅ 新增集成测试：并发写入 50 条 API 记录 + 10 条资源采样，无锁冲突

## 影响范围

- 仅影响 SQLite 个人模式
- PostgreSQL 服务模式不受影响
- 向后兼容，无破坏性变更

## 测试结果

```
✓ Wrote 50 API calls and 10 resource samples without lock errors
================== 1 passed in 1.59s ==================
```

Closes #3